### PR TITLE
Add fee_utxo to Instruction

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -268,7 +268,7 @@ fn open_pool_test(txid: String, vout: u32, program_id: Pubkey, fee_txid: String,
             block: 1,
             tx: 4
         },
-        fee_txid,
+        fee_txid: fee_txid.clone(),
         fee_vout,
         buy_fee: None,
         sell_fee: None,
@@ -286,7 +286,11 @@ fn open_pool_test(txid: String, vout: u32, program_id: Pubkey, fee_txid: String,
             UtxoMeta {
                 txid,
                 vout
-            }
+            },
+            UtxoMeta {
+                txid: fee_txid.clone(),
+                vout
+            },
         ],
         data: instruction_data
     };

--- a/src/main.rs
+++ b/src/main.rs
@@ -289,7 +289,7 @@ fn open_pool_test(txid: String, vout: u32, program_id: Pubkey, fee_txid: String,
             },
             UtxoMeta {
                 txid: fee_txid.clone(),
-                vout
+                vout: fee_vout,
             },
         ],
         data: instruction_data


### PR DESCRIPTION
- In https://github.com/Arch-Network/arch-network/pull/17 we added a check that program can only spend UTXOs that are present in Instruction so we have to adapt the tests because currently Program is spending fee UTXO that is not present in Instruction